### PR TITLE
Case ref on feedback can be 9 char beginning with 02

### DIFF
--- a/features/feature_files/feedback.feature
+++ b/features/feature_files/feedback.feature
@@ -61,6 +61,28 @@ Feature: Feedback form
       | 2222222T  |
       | eightchr  |
       | 01234567  |
+      | 02345678  |
+      | 012345678 |
+      | 0234567666 |
+      | 23456789 ! |
+
+  Scenario Outline: Valid Case IDs
+    #Given Caseworker is using the Income Proving Service Case Worker Tool
+    Given the account data for TL123456A
+    And the income check is performed
+    And the feedback form is completed
+      | match   | No    |
+      | caseref | <ref> |
+    When the submit button is clicked
+    Then the following are hidden
+      | caseref-error |
+    Examples:
+      | ref        |
+      | 23456789   |
+      | 29876543   |
+      | 023456789  |
+      | 029876543  |
+      
 
     #### PASSED ####
 

--- a/src/app/modules/familymigration/familymigrationResult.js
+++ b/src/app/modules/familymigration/familymigrationResult.js
@@ -167,12 +167,13 @@ familymigrationModule.controller('FamilymigrationResultCtrl',
       }
     },
     caseref: {
-      length: 8,
+      // length: 9,
       classes: {'form-control-1-4': false},
       validate: function (val) {
         if (val) {
-          var v = val.replace(/[^a-zA-Z0-9]/g, '')
-          if (/^2[0-9]{7}$/.test(v)) {
+          var v = val.trim()
+          // var v = val.replace(/[^a-zA-Z0-9]/g, '')
+          if (/^(2|02)[0-9]{7}$/.test(v)) {
             return true
           }
         }


### PR DESCRIPTION
The IPS is currently configured to accept a case ID with a maximum of 8 digits starting with the number '2'. This is derived from user research on the correct format of case IDs.

The case ID is displayed in the CID caseworking system in two formats however; one as a 9-digit number starting with the digit '0' (021234567 - for example), to account for when the system moves onto case IDs requiring 9 digits. And two, as an 8-digit number in the format that the IPS is currently configured to.

When a user copies and pastes the case ID containing 9 digits and starting with '0' into the IPS, validation settings inform the user that this is incorrect, when in fact, technically it is correct.