### PR TITLE
EE-15653: Include details polyfill as npm package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,6 +52,7 @@ var config = {
 
 gulp.task('assets', function () {
   gulp.src([sourcePath + 'assets/**/*']).pipe(gulp.dest(target + 'assets'))
+  gulp.src(['node_modules/details-element-polyfill/dist/*']).pipe(gulp.dest(target + 'assets'))
 })
 
 gulp.task('sassjs', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2615,6 +2615,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "details-element-polyfill": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/details-element-polyfill/-/details-element-polyfill-2.3.1.tgz",
+      "integrity": "sha512-7Gr2pBgSpeSvBGBWjMESJ7WClexq3A5/HlZ2ZVgG4OjNvTgRfCEe0+ZEfT44JymqCtHd04+pSrgYg4W6yok/6w=="
+    },
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "async": "^2.5.0",
     "body-parser": "^1.18.2",
     "clipboard": "^1.7.1",
+    "details-element-polyfill": "^2.3.1",
     "express": "^4.16.0",
     "govuk-elements-sass": "^2.2.1",
     "govuk_frontend_toolkit": "^5.2.0",

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
     <script type="text/javascript">
       (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     </script>
+    <script type="text/javascript" src="../assets/details-element-polyfill.js"></script>
 
     <!--[if gt IE 8]><!--><link href="/assets/stylesheets/govuk-template.css?0.17.3" media="screen" rel="stylesheet" /><!--<![endif]-->
     <!--[if IE 6]><link href="/assets/stylesheets/govuk-template-ie6.css?0.17.3" media="screen" rel="stylesheet" /><![endif]-->


### PR DESCRIPTION
A cleaner way of incorporating a details polyfill giving incompatible browsers the ability to display a HTML5 details/summary collapsible block.