### PR TITLE
Ee 15890 image scan

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -94,6 +94,14 @@ pipeline:
     when:
       event: tag
 
+  scan:
+    image: quay.io/ukhomeofficedigital/anchore-submission:latest
+    dockerfile: Dockerfile
+    image_name: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:${DRONE_COMMIT_SHA:0:8}
+    local_image: true
+    tolerate: low
+    show_all_vulnerabilities: true
+
   trigger-e2e-tests:
     image: quay.io/ukhomeofficedigital/drone-trigger:v0.3.0
     secrets:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,14 +13,12 @@ pipeline:
       event: [push]
 
   npm-audit:
-    image: docker:17.09.1
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
+    image: node:12
     commands:
       - npm audit --audit-level=moderate --only=prod
     when:
       event: push
-      
+
   build-docker-image:
     image: docker:17.09.1
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,8 @@ pipeline:
   npm-audit:
     image: node:12
     commands:
-      - npm audit --audit-level=moderate --only=prod
+      # TODO EE-29064 remove skip so that build fails for new errors.
+      - npm audit --audit-level=moderate --only=prod || echo Temporarily skipping failure until EE-29064 is resolved
     when:
       event: push
 
@@ -33,8 +34,9 @@ pipeline:
     dockerfile: Dockerfile
     image_name: pttg-ip-fm-ui
     local_image: true
-    tolerate: low
+    tolerate: medium
     show_all_vulnerabilities: true
+    fail_on_detection: false # TODO EE-29064 Remove this when current vulnerabilities are resolved
     when:
       event: push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,14 @@ pipeline:
     when:
       event: push
 
+  scan:
+    image: quay.io/ukhomeofficedigital/anchore-submission:latest
+    dockerfile: Dockerfile
+    image_name: pttg-ip-fm-ui
+    local_image: true
+    tolerate: low
+    show_all_vulnerabilities: true
+
   test:
     image: docker:17.09.1
     environment:
@@ -93,14 +101,6 @@ pipeline:
       - docker push quay.io/ukhomeofficedigital/pttg-ip-fm-ui:$(cat ./tagSemver)
     when:
       event: tag
-
-  scan:
-    image: quay.io/ukhomeofficedigital/anchore-submission:latest
-    dockerfile: Dockerfile
-    image_name: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:${DRONE_COMMIT_SHA:0:8}
-    local_image: true
-    tolerate: low
-    show_all_vulnerabilities: true
 
   trigger-e2e-tests:
     image: quay.io/ukhomeofficedigital/drone-trigger:v0.3.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,21 +12,21 @@ pipeline:
       branch: master
       event: [push]
 
-  build-docker-image:
-    image: docker:17.09.1
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker build -t pttg-ip-fm-ui .
-    when:
-      event: push
-
   npm-audit:
     image: docker:17.09.1
     environment:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
       - npm audit --audit-level=moderate --only=prod
+    when:
+      event: push
+      
+  build-docker-image:
+    image: docker:17.09.1
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker build -t pttg-ip-fm-ui .
     when:
       event: push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,15 @@ pipeline:
     when:
       event: push
 
+  npm-audit:
+    image: docker:17.09.1
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - npm audit --audit-level=moderate --only=prod
+    when:
+      event: push
+
   scan:
     image: quay.io/ukhomeofficedigital/anchore-submission:latest
     dockerfile: Dockerfile
@@ -28,6 +37,8 @@ pipeline:
     local_image: true
     tolerate: low
     show_all_vulnerabilities: true
+    when:
+      event: push
 
   test:
     image: docker:17.09.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -8380,7 +8380,8 @@
             },
             "tar": {
               "version": "4.4.1",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+              "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
               "dev": true,
               "optional": true,
               "requires": {


### PR DESCRIPTION
Added vulnerability scanning to the build. I think that some vulnerabilities turn up only in the npm audit or the Dockerfile scan so I've added both. As the npm audit command takes 20 seconds, it seems smart to do that early.

We have vulnerabilities that would fail the build - EE-29064 so I've temporarily skipped the failures and added a TODO.

As it's only build changes I intend to merge once approved.